### PR TITLE
Implement the Sincere Loyalty upgrade

### DIFF
--- a/src/main/java/ladysnake/impaled/common/item/ImpaledTridentItem.java
+++ b/src/main/java/ladysnake/impaled/common/item/ImpaledTridentItem.java
@@ -9,17 +9,17 @@ import net.minecraft.entity.damage.DamageSource;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.entity.projectile.PersistentProjectileEntity;
 import net.minecraft.item.ItemStack;
-import net.minecraft.item.Items;
 import net.minecraft.item.TridentItem;
 import net.minecraft.sound.SoundCategory;
 import net.minecraft.sound.SoundEvent;
 import net.minecraft.sound.SoundEvents;
 import net.minecraft.stat.Stats;
-import net.minecraft.util.Hand;
-import net.minecraft.util.TypedActionResult;
 import net.minecraft.util.math.MathHelper;
 import net.minecraft.util.math.Vec3d;
 import net.minecraft.world.World;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Objects;
 
 public class ImpaledTridentItem extends TridentItem {
     EntityType<ImpaledTridentEntity> type;
@@ -44,12 +44,8 @@ public class ImpaledTridentItem extends TridentItem {
                     if (!world.isClient) {
                         stack.damage(1, (LivingEntity) playerEntity, livingEntity -> livingEntity.sendToolBreakStatus(user.getActiveHand()));
                         if (j == 0) {
-                            ImpaledTridentEntity impaledTridentEntity = this.type.create(world);
-                            impaledTridentEntity.setTridentAttributes(world, playerEntity, stack);
-                            impaledTridentEntity.setOwner(playerEntity);
-                            impaledTridentEntity.setTridentStack(stack);
-                            impaledTridentEntity.setProperties(playerEntity, playerEntity.pitch, playerEntity.yaw, 0.0F, 2.5F + (float) j * 0.5F, 1.0F);
-                            impaledTridentEntity.updatePosition(user.getX(), user.getEyeY() - 0.10000000149011612D, user.getZ());
+                            ImpaledTridentEntity impaledTridentEntity = createTrident(world, playerEntity, stack);
+
                             if (playerEntity.getAbilities().creativeMode) {
                                 impaledTridentEntity.pickupType = PersistentProjectileEntity.PickupPermission.CREATIVE_ONLY;
                             }
@@ -96,6 +92,16 @@ public class ImpaledTridentItem extends TridentItem {
                 }
             }
         }
+    }
+
+    public @NotNull ImpaledTridentEntity createTrident(World world, LivingEntity user, ItemStack stack) {
+        ImpaledTridentEntity impaledTridentEntity = Objects.requireNonNull(this.type.create(world));
+        impaledTridentEntity.setTridentAttributes(world, user, stack);
+        impaledTridentEntity.setOwner(user);
+        impaledTridentEntity.setTridentStack(stack);
+        impaledTridentEntity.setProperties(user, user.pitch, user.yaw, 0.0F, 2.5F, 1.0F);
+        impaledTridentEntity.updatePosition(user.getX(), user.getEyeY() - 0.1, user.getZ());
+        return impaledTridentEntity;
     }
 
     @Override

--- a/src/main/java/ladysnake/sincereloyalty/LoyalTrident.java
+++ b/src/main/java/ladysnake/sincereloyalty/LoyalTrident.java
@@ -1,0 +1,114 @@
+/*
+ * Sincere-Loyalty
+ * Copyright (C) 2020 Ladysnake
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; If not, see <https://www.gnu.org/licenses>.
+ */
+package ladysnake.sincereloyalty;
+
+import net.minecraft.enchantment.EnchantmentHelper;
+import net.minecraft.entity.Entity;
+import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.entity.projectile.TridentEntity;
+import net.minecraft.item.ItemStack;
+import net.minecraft.nbt.CompoundTag;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.Objects;
+import java.util.UUID;
+
+public interface LoyalTrident {
+    String MOD_NBT_KEY = SincereLoyalty.MOD_ID;
+    String TRIDENT_UUID_NBT_KEY = "trident_uuid";
+    String OWNER_NAME_NBT_KEY = "owner_name";
+    String TRIDENT_OWNER_NBT_KEY = "trident_owner";
+    String TRIDENT_SIT_NBT_KEY = MOD_NBT_KEY + ":trident_sit";
+    String RETURN_SLOT_NBT_KEY = "return_slot";
+
+    static LoyalTrident of(TridentEntity trident) {
+        return ((LoyalTrident) trident);
+    }
+
+    @Nullable
+    static UUID getTridentUuid(ItemStack stack) {
+        CompoundTag loyaltyData = stack.getSubTag(LoyalTrident.MOD_NBT_KEY);
+        if (loyaltyData == null || !loyaltyData.containsUuid(TRIDENT_OWNER_NBT_KEY)) {
+            return null;
+        }
+        if (!loyaltyData.containsUuid(TRIDENT_UUID_NBT_KEY)) {
+            loyaltyData.putUuid(LoyalTrident.TRIDENT_UUID_NBT_KEY, UUID.randomUUID());
+        }
+        return loyaltyData.getUuid(TRIDENT_UUID_NBT_KEY);
+    }
+
+    static void setPreferredSlot(ItemStack tridentStack, int slot) {
+        tridentStack.getOrCreateSubTag(LoyalTrident.MOD_NBT_KEY).putInt(LoyalTrident.RETURN_SLOT_NBT_KEY, slot);
+    }
+
+    static boolean hasSittingFlag(ItemStack tridentStack) {
+        CompoundTag loyaltyData = tridentStack.getSubTag(LoyalTrident.MOD_NBT_KEY);
+        return loyaltyData != null && loyaltyData.getBoolean(LoyalTrident.TRIDENT_SIT_NBT_KEY);
+    }
+
+    static void addSittingFlag(ItemStack tridentStack) {
+        tridentStack.getOrCreateSubTag(LoyalTrident.MOD_NBT_KEY).putBoolean(LoyalTrident.TRIDENT_SIT_NBT_KEY, true);
+    }
+
+    static void clearSittingFlag(ItemStack tridentStack) {
+        CompoundTag loyaltyData = tridentStack.getSubTag(LoyalTrident.MOD_NBT_KEY);
+        if (loyaltyData != null) {
+            loyaltyData.remove(LoyalTrident.TRIDENT_SIT_NBT_KEY);
+        }
+    }
+
+    static boolean hasTrueOwner(ItemStack tridentStack) {
+        if (SincereLoyalty.TRIDENTS.contains(tridentStack.getItem()) && EnchantmentHelper.getLoyalty(tridentStack) > 0) {
+            CompoundTag loyaltyNbt = tridentStack.getSubTag(MOD_NBT_KEY);
+            return loyaltyNbt != null && loyaltyNbt.containsUuid(TRIDENT_OWNER_NBT_KEY);
+        }
+        return false;
+    }
+
+    @Nullable
+    static UUID getTrueOwner(ItemStack tridentStack) {
+        return hasTrueOwner(tridentStack) ? Objects.requireNonNull(tridentStack.getSubTag(MOD_NBT_KEY)).getUuid(TRIDENT_OWNER_NBT_KEY) : null;
+    }
+
+    @Nullable
+    static TridentEntity spawnTridentForStack(Entity thrower, ItemStack tridentStack) {
+        CompoundTag loyaltyData = tridentStack.getSubTag(MOD_NBT_KEY);
+        if (loyaltyData != null) {
+            UUID ownerUuid = loyaltyData.getUuid(TRIDENT_OWNER_NBT_KEY);
+            if (ownerUuid != null) {
+                PlayerEntity owner = thrower.world.getPlayerByUuid(ownerUuid);
+                if (owner != null) {
+                    TridentEntity trident = new TridentEntity(thrower.world, owner, tridentStack);
+                    trident.setVelocity(thrower.getVelocity());
+                    trident.copyPositionAndRotation(thrower);
+                    thrower.world.spawnEntity(trident);
+                    return trident;
+                }
+            }
+        }
+        return null;
+    }
+
+    UUID loyaltrident_getTridentUuid();
+
+    void loyaltrident_sit();
+
+    void loyaltrident_wakeUp();
+
+    void loyaltrident_setReturnSlot(int slot);
+}

--- a/src/main/java/ladysnake/sincereloyalty/LoyalTrident.java
+++ b/src/main/java/ladysnake/sincereloyalty/LoyalTrident.java
@@ -17,9 +17,12 @@
  */
 package ladysnake.sincereloyalty;
 
+import ladysnake.impaled.common.init.ImpaledItems;
+import ladysnake.impaled.common.item.ImpaledTridentItem;
 import net.minecraft.enchantment.EnchantmentHelper;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.entity.projectile.PersistentProjectileEntity;
 import net.minecraft.entity.projectile.TridentEntity;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.CompoundTag;
@@ -93,7 +96,17 @@ public interface LoyalTrident {
             if (ownerUuid != null) {
                 PlayerEntity owner = thrower.world.getPlayerByUuid(ownerUuid);
                 if (owner != null) {
-                    TridentEntity trident = new TridentEntity(thrower.world, owner, tridentStack);
+                    TridentEntity trident;
+
+                    // Yes it is fine to call Set<TridentItem>#contains(Item)
+                    //noinspection SuspiciousMethodCalls
+                    if (ImpaledItems.ALL_TRIDENTS.contains(tridentStack.getItem())) {
+                        trident = ((ImpaledTridentItem) tridentStack.getItem()).createTrident(thrower.world, owner, tridentStack);
+                    } else {
+                        trident = new TridentEntity(thrower.world, owner, tridentStack);
+                    }
+
+                    trident.pickupType = PersistentProjectileEntity.PickupPermission.ALLOWED;
                     trident.setVelocity(thrower.getVelocity());
                     trident.copyPositionAndRotation(thrower);
                     thrower.world.spawnEntity(trident);

--- a/src/main/java/ladysnake/sincereloyalty/SincereLoyalty.java
+++ b/src/main/java/ladysnake/sincereloyalty/SincereLoyalty.java
@@ -1,0 +1,82 @@
+/*
+ * Sincere-Loyalty
+ * Copyright (C) 2020 Ladysnake
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; If not, see <https://www.gnu.org/licenses>.
+ */
+package ladysnake.sincereloyalty;
+
+import ladysnake.impaled.common.Impaled;
+import ladysnake.sincereloyalty.storage.LoyalTridentStorage;
+import net.fabricmc.api.ModInitializer;
+import net.fabricmc.fabric.api.network.ServerSidePacketRegistry;
+import net.fabricmc.fabric.api.networking.v1.PacketSender;
+import net.fabricmc.fabric.api.networking.v1.ServerPlayNetworking;
+import net.fabricmc.fabric.api.tag.TagRegistry;
+import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.item.Item;
+import net.minecraft.network.PacketByteBuf;
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.server.network.ServerPlayNetworkHandler;
+import net.minecraft.server.network.ServerPlayerEntity;
+import net.minecraft.server.world.ServerWorld;
+import net.minecraft.tag.Tag;
+import net.minecraft.text.TranslatableText;
+import net.minecraft.util.Identifier;
+
+public final class SincereLoyalty implements ModInitializer {
+
+    public static final String MOD_ID = Impaled.MODID;
+
+    public static final Tag<Item> LOYALTY_CATALYSTS = TagRegistry.item(id("loyalty_catalysts"));
+    public static final Tag<Item> TRIDENTS = TagRegistry.item(id("tridents"));
+
+    public static final Identifier RECALL_TRIDENTS_MESSAGE_ID = id("recall_tridents");
+    public static final Identifier RECALLING_MESSAGE_ID = id("recalling_tridents");
+
+    public static Identifier id(String path) {
+        return new Identifier(MOD_ID, path);
+    }
+
+    @Override
+    public void onInitialize() {
+        ServerPlayNetworking.registerGlobalReceiver(RECALL_TRIDENTS_MESSAGE_ID, (MinecraftServer server, ServerPlayerEntity player, ServerPlayNetworkHandler handler, PacketByteBuf buf, PacketSender responseSender) -> {
+            TridentRecaller.RecallStatus requested = buf.readEnumConstant(TridentRecaller.RecallStatus.class);
+
+            server.execute(() -> {
+                LoyalTridentStorage loyalTridentStorage = LoyalTridentStorage.get(player.getServerWorld());
+                TridentRecaller.RecallStatus currentRecallStatus = ((TridentRecaller) player).getCurrentRecallStatus();
+                TridentRecaller.RecallStatus newRecallStatus;
+
+                if (loyalTridentStorage.hasTridents(player)) {
+                    if (currentRecallStatus != requested && requested == TridentRecaller.RecallStatus.RECALLING) {
+                        // if there is no trident to recall, reset the player's animation
+                        if (loyalTridentStorage.recallTridents(player)) {
+                            newRecallStatus = TridentRecaller.RecallStatus.RECALLING;
+                        } else {
+                            player.sendMessage(new TranslatableText("impaled:trident_recall_fail"), true);
+                            newRecallStatus = TridentRecaller.RecallStatus.NONE;
+                        }
+                    } else {
+                        newRecallStatus = requested;
+                    }
+                } else {
+                    newRecallStatus = TridentRecaller.RecallStatus.NONE;
+                }
+
+                ((TridentRecaller) player).updateRecallStatus(newRecallStatus);
+            });
+        });
+    }
+}

--- a/src/main/java/ladysnake/sincereloyalty/SincereLoyaltyClient.java
+++ b/src/main/java/ladysnake/sincereloyalty/SincereLoyaltyClient.java
@@ -1,0 +1,88 @@
+/*
+ * Sincere-Loyalty
+ * Copyright (C) 2020 Ladysnake
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; If not, see <https://www.gnu.org/licenses>.
+ */
+package ladysnake.sincereloyalty;
+
+import net.fabricmc.api.ClientModInitializer;
+import net.fabricmc.fabric.api.client.event.lifecycle.v1.ClientTickEvents;
+import net.fabricmc.fabric.api.client.networking.v1.ClientPlayNetworking;
+import net.fabricmc.fabric.api.networking.v1.PacketByteBufs;
+import net.fabricmc.fabric.api.networking.v1.PacketSender;
+import net.minecraft.client.MinecraftClient;
+import net.minecraft.client.network.ClientPlayNetworkHandler;
+import net.minecraft.entity.Entity;
+import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.network.PacketByteBuf;
+import org.jetbrains.annotations.Nullable;
+
+public final class SincereLoyaltyClient implements ClientModInitializer {
+    public static final SincereLoyaltyClient INSTANCE = new SincereLoyaltyClient();
+    public static final int RECALL_ANIMATION_START = 10;
+    public static final int RECALL_TIME = 40;
+
+    private int useTime = 0;
+    private int failedUseCountdown = 0;
+
+    public void setFailedUse(int itemUseCooldown) {
+        this.failedUseCountdown = itemUseCooldown + 1;
+    }
+
+    @Override
+    public void onInitializeClient() {
+        ClientTickEvents.END_CLIENT_TICK.register(mc -> {
+            TridentRecaller.RecallStatus recalling = tickTridentRecalling(mc);
+            if (recalling != null) {
+                PacketByteBuf buf = PacketByteBufs.create();
+                buf.writeEnumConstant(recalling);
+                ClientPlayNetworking.send(SincereLoyalty.RECALL_TRIDENTS_MESSAGE_ID, buf);
+            }
+        });
+        ClientPlayNetworking.registerGlobalReceiver(SincereLoyalty.RECALLING_MESSAGE_ID, (MinecraftClient client, ClientPlayNetworkHandler handler, PacketByteBuf buf, PacketSender responseSender) -> {
+            int playerId = buf.readInt();
+            TridentRecaller.RecallStatus recalling = buf.readEnumConstant(TridentRecaller.RecallStatus.class);
+            client.execute(() -> {
+                Entity player = client.world.getEntityById(playerId);
+                if (player instanceof TridentRecaller) {
+                    ((TridentRecaller) player).updateRecallStatus(recalling);
+                }
+            });
+        });
+    }
+
+    @Nullable
+    private TridentRecaller.RecallStatus tickTridentRecalling(MinecraftClient mc) {
+        if (this.failedUseCountdown > 0) {
+            PlayerEntity player = mc.player;
+
+            if (player != null && player.getMainHandStack().isEmpty()) {
+                ++this.useTime;
+
+                if (this.useTime == RECALL_ANIMATION_START) {
+                    return TridentRecaller.RecallStatus.CHARGING;
+                } else if (this.useTime == RECALL_TIME) {
+                    this.useTime = 0;
+                    return TridentRecaller.RecallStatus.RECALLING;
+                }
+            }
+            this.failedUseCountdown--;
+        } else if (this.useTime > 0) {
+            this.useTime = 0;
+            return TridentRecaller.RecallStatus.NONE;
+        }
+        return null;
+    }
+}

--- a/src/main/java/ladysnake/sincereloyalty/TridentRecaller.java
+++ b/src/main/java/ladysnake/sincereloyalty/TridentRecaller.java
@@ -1,0 +1,35 @@
+/*
+ * Sincere-Loyalty
+ * Copyright (C) 2020 Ladysnake
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; If not, see <https://www.gnu.org/licenses>.
+ */
+package ladysnake.sincereloyalty;
+
+import org.jetbrains.annotations.Contract;
+
+public interface TridentRecaller {
+    /**
+     * Returns {@code true} if the status was changed through this call
+     */
+    // no need for a prefix, the signature has a custom type
+    void updateRecallStatus(RecallStatus recalling);
+
+    @Contract(pure = true)
+    RecallStatus getCurrentRecallStatus();
+
+    enum RecallStatus {
+        CHARGING, NONE, RECALLING
+    }
+}

--- a/src/main/java/ladysnake/sincereloyalty/mixin/ItemEntityMixin.java
+++ b/src/main/java/ladysnake/sincereloyalty/mixin/ItemEntityMixin.java
@@ -1,0 +1,68 @@
+/*
+ * Sincere-Loyalty
+ * Copyright (C) 2020 Ladysnake
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; If not, see <https://www.gnu.org/licenses>.
+ */
+package ladysnake.sincereloyalty.mixin;
+
+import ladysnake.sincereloyalty.LoyalTrident;
+import net.minecraft.entity.Entity;
+import net.minecraft.entity.EntityType;
+import net.minecraft.entity.ItemEntity;
+import net.minecraft.entity.projectile.TridentEntity;
+import net.minecraft.item.ItemStack;
+import net.minecraft.world.World;
+import org.jetbrains.annotations.Nullable;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.Unique;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(ItemEntity.class)
+public abstract class ItemEntityMixin extends Entity {
+    public ItemEntityMixin(EntityType<?> type, World world) {
+        super(type, world);
+    }
+
+    @Shadow
+    public abstract ItemStack getStack();
+
+    @Shadow
+    public abstract boolean cannotPickup();
+
+    @Nullable
+    @Unique
+    private Boolean veryLoyalTrident;
+
+    @Inject(method = "tick", at = @At("HEAD"), cancellable = true)
+    private void tickItem(CallbackInfo ci) {
+        // Only spawn a trident if it has a pickup delay (usually sign of it being dropped by a player)
+        if (!this.world.isClient && this.cannotPickup()) {
+            if (this.veryLoyalTrident == null) {
+                this.veryLoyalTrident = LoyalTrident.hasTrueOwner(this.getStack());
+            }
+            if (this.veryLoyalTrident) {
+                TridentEntity tridentEntity = LoyalTrident.spawnTridentForStack(this, this.getStack());
+                if (tridentEntity != null) {
+                    LoyalTrident.of(tridentEntity).loyaltrident_sit();
+                    this.discard();
+                    ci.cancel();
+                }
+            }
+        }
+    }
+}

--- a/src/main/java/ladysnake/sincereloyalty/mixin/ItemMixin.java
+++ b/src/main/java/ladysnake/sincereloyalty/mixin/ItemMixin.java
@@ -1,0 +1,53 @@
+/*
+ * Sincere-Loyalty
+ * Copyright (C) 2020 Ladysnake
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; If not, see <https://www.gnu.org/licenses>.
+ */
+package ladysnake.sincereloyalty.mixin;
+
+import ladysnake.sincereloyalty.LoyalTrident;
+import ladysnake.sincereloyalty.storage.LoyalTridentStorage;
+import net.minecraft.entity.Entity;
+import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.item.Item;
+import net.minecraft.item.ItemStack;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.server.world.ServerWorld;
+import net.minecraft.world.World;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import java.util.Objects;
+import java.util.UUID;
+
+@Mixin(Item.class)
+public abstract class ItemMixin {
+    @Inject(method = "inventoryTick", at = @At("RETURN"))
+    private void updateTridentInInventory(ItemStack stack, World world, Entity entity, int slot, boolean selected, CallbackInfo ci) {
+        if (entity.age % 10 == 0 && !entity.world.isClient && entity instanceof PlayerEntity) {
+            UUID trueOwner = LoyalTrident.getTrueOwner(stack);
+            if (Objects.equals(trueOwner, entity.getUuid())) {
+                CompoundTag loyaltyData = Objects.requireNonNull(stack.getSubTag(LoyalTrident.MOD_NBT_KEY));
+                if (!Objects.equals(entity.getEntityName(), loyaltyData.getString(LoyalTrident.OWNER_NAME_NBT_KEY))) {
+                    loyaltyData.putString(LoyalTrident.OWNER_NAME_NBT_KEY, entity.getEntityName());
+                }
+            } else if (trueOwner != null){
+                LoyalTridentStorage.get((ServerWorld) world).memorizeTrident(trueOwner, LoyalTrident.getTridentUuid(stack), (PlayerEntity) entity);
+            }
+        }
+    }
+}

--- a/src/main/java/ladysnake/sincereloyalty/mixin/PlayerEntityMixin.java
+++ b/src/main/java/ladysnake/sincereloyalty/mixin/PlayerEntityMixin.java
@@ -1,0 +1,67 @@
+/*
+ * Sincere-Loyalty
+ * Copyright (C) 2020 Ladysnake
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; If not, see <https://www.gnu.org/licenses>.
+ */
+package ladysnake.sincereloyalty.mixin;
+
+import ladysnake.sincereloyalty.SincereLoyalty;
+import ladysnake.sincereloyalty.TridentRecaller;
+import net.fabricmc.fabric.api.networking.v1.PacketByteBufs;
+import net.fabricmc.fabric.api.networking.v1.PlayerLookup;
+import net.fabricmc.fabric.api.networking.v1.ServerPlayNetworking;
+import net.minecraft.entity.EntityType;
+import net.minecraft.entity.LivingEntity;
+import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.network.Packet;
+import net.minecraft.network.PacketByteBuf;
+import net.minecraft.server.network.ServerPlayerEntity;
+import net.minecraft.world.World;
+import org.jetbrains.annotations.NotNull;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Unique;
+
+@Mixin(PlayerEntity.class)
+public abstract class PlayerEntityMixin extends LivingEntity implements TridentRecaller {
+    @NotNull
+    @Unique
+    private RecallStatus recallingTrident = RecallStatus.NONE;
+
+    protected PlayerEntityMixin(EntityType<? extends LivingEntity> entityType, World world) {
+        super(entityType, world);
+    }
+
+    @Override
+    public RecallStatus getCurrentRecallStatus() {
+        return this.recallingTrident;
+    }
+
+    @Override
+    public void updateRecallStatus(RecallStatus recallingTrident) {
+        if (this.recallingTrident != recallingTrident) {
+            this.recallingTrident = recallingTrident;
+            if (!this.world.isClient) {
+                PacketByteBuf res = PacketByteBufs.create();
+                res.writeInt(this.getId());
+                res.writeEnumConstant(recallingTrident);
+                Packet<?> packet = ServerPlayNetworking.createS2CPacket(SincereLoyalty.RECALLING_MESSAGE_ID, res);
+                ((ServerPlayerEntity) (Object) this).networkHandler.sendPacket(packet);
+                for (ServerPlayerEntity player : PlayerLookup.tracking(this)) {
+                    player.networkHandler.sendPacket(packet);
+                }
+            }
+        }
+    }
+}

--- a/src/main/java/ladysnake/sincereloyalty/mixin/PlayerInventoryMixin.java
+++ b/src/main/java/ladysnake/sincereloyalty/mixin/PlayerInventoryMixin.java
@@ -1,0 +1,62 @@
+/*
+ * Sincere-Loyalty
+ * Copyright (C) 2020 Ladysnake
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; If not, see <https://www.gnu.org/licenses>.
+ */
+package ladysnake.sincereloyalty.mixin;
+
+import ladysnake.sincereloyalty.LoyalTrident;
+import ladysnake.sincereloyalty.TridentRecaller;
+import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.entity.player.PlayerInventory;
+import net.minecraft.item.ItemStack;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.sound.SoundEvents;
+import org.spongepowered.asm.mixin.Final;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.ModifyArg;
+
+@Mixin(PlayerInventory.class)
+public abstract class PlayerInventoryMixin {
+
+    @Shadow
+    public abstract ItemStack getStack(int slot);
+
+    @Shadow
+    @Final
+    public PlayerEntity player;
+
+    @ModifyArg(method = "insertStack(Lnet/minecraft/item/ItemStack;)Z", at = @At(value = "INVOKE", target = "Lnet/minecraft/entity/player/PlayerInventory;insertStack(ILnet/minecraft/item/ItemStack;)Z"))
+    private int insertToPreferredSlot(int slot, ItemStack stack) {
+        CompoundTag tag = stack.getSubTag(LoyalTrident.MOD_NBT_KEY);
+        if (tag != null) {
+            if (tag.contains(LoyalTrident.RETURN_SLOT_NBT_KEY)) {
+                int preferredSlot = tag.getInt(LoyalTrident.RETURN_SLOT_NBT_KEY);
+                if (this.getStack(preferredSlot).isEmpty()) {
+                    return preferredSlot;
+                }
+            }
+
+            TridentRecaller caller = (TridentRecaller) this.player;
+            if (caller.getCurrentRecallStatus() == TridentRecaller.RecallStatus.RECALLING) {
+                player.world.playSound(null, player.getX(), player.getY(), player.getZ(), SoundEvents.ITEM_TRIDENT_RETURN, player.getSoundCategory(), 0.7f, 0.5f);
+            }
+            caller.updateRecallStatus(TridentRecaller.RecallStatus.NONE);
+        }
+        return slot;
+    }
+}

--- a/src/main/java/ladysnake/sincereloyalty/mixin/ProjectileAccessor.java
+++ b/src/main/java/ladysnake/sincereloyalty/mixin/ProjectileAccessor.java
@@ -1,0 +1,30 @@
+/*
+ * Sincere-Loyalty
+ * Copyright (C) 2020 Ladysnake
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; If not, see <https://www.gnu.org/licenses>.
+ */
+package ladysnake.sincereloyalty.mixin;
+
+import net.minecraft.entity.projectile.ProjectileEntity;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Accessor;
+
+import java.util.UUID;
+
+@Mixin(ProjectileEntity.class)
+public interface ProjectileAccessor {
+    @Accessor
+    UUID getOwnerUuid();
+}

--- a/src/main/java/ladysnake/sincereloyalty/mixin/ServerPlayNetworkHandlerMixin.java
+++ b/src/main/java/ladysnake/sincereloyalty/mixin/ServerPlayNetworkHandlerMixin.java
@@ -1,0 +1,38 @@
+/*
+ * Sincere-Loyalty
+ * Copyright (C) 2020 Ladysnake
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; If not, see <https://www.gnu.org/licenses>.
+ */
+package ladysnake.sincereloyalty.mixin;
+
+import ladysnake.sincereloyalty.LoyalTrident;
+import net.minecraft.item.ItemStack;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.server.network.ServerPlayNetworkHandler;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.ModifyVariable;
+
+@Mixin(ServerPlayNetworkHandler.class)
+public abstract class ServerPlayNetworkHandlerMixin {
+    @ModifyVariable(method = "onCreativeInventoryAction", at = @At(value = "INVOKE_ASSIGN", target = "Lnet/minecraft/network/packet/c2s/play/CreativeInventoryActionC2SPacket;getItemStack()Lnet/minecraft/item/ItemStack;"))
+    private ItemStack removeTridentUuid(ItemStack copiedStack) {
+        CompoundTag compoundTag = copiedStack.getSubTag(LoyalTrident.MOD_NBT_KEY);
+        if (compoundTag != null) {
+            compoundTag.remove(LoyalTrident.TRIDENT_UUID_NBT_KEY);  // prevent stupid copies of the exact same trident
+        }
+        return copiedStack;
+    }
+}

--- a/src/main/java/ladysnake/sincereloyalty/mixin/SmithingScreenHandlerMixin.java
+++ b/src/main/java/ladysnake/sincereloyalty/mixin/SmithingScreenHandlerMixin.java
@@ -1,0 +1,86 @@
+/*
+ * Sincere-Loyalty
+ * Copyright (C) 2020 Ladysnake
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; If not, see <https://www.gnu.org/licenses>.
+ */
+package ladysnake.sincereloyalty.mixin;
+
+import ladysnake.sincereloyalty.LoyalTrident;
+import ladysnake.sincereloyalty.SincereLoyalty;
+import net.minecraft.enchantment.Enchantment;
+import net.minecraft.enchantment.EnchantmentHelper;
+import net.minecraft.enchantment.Enchantments;
+import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.entity.player.PlayerInventory;
+import net.minecraft.item.ItemStack;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.screen.ForgingScreenHandler;
+import net.minecraft.screen.ScreenHandlerContext;
+import net.minecraft.screen.ScreenHandlerType;
+import net.minecraft.screen.SmithingScreenHandler;
+import org.jetbrains.annotations.Nullable;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.ModifyArg;
+import org.spongepowered.asm.mixin.injection.Slice;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+import java.util.Map;
+
+@Mixin(SmithingScreenHandler.class)
+public abstract class SmithingScreenHandlerMixin extends ForgingScreenHandler {
+    public SmithingScreenHandlerMixin(@Nullable ScreenHandlerType<?> type, int syncId, PlayerInventory playerInventory, ScreenHandlerContext context) {
+        super(type, syncId, playerInventory, context);
+    }
+
+    @Inject(method = "canTakeOutput", at = @At("RETURN"), cancellable = true)
+    private void canTakeResult(PlayerEntity playerEntity, boolean resultNonEmpty, CallbackInfoReturnable<Boolean> cir) {
+        if (resultNonEmpty && !cir.getReturnValueZ()) {
+            ItemStack item = this.input.getStack(0);
+            ItemStack upgradeItem = this.input.getStack(1);
+            cir.setReturnValue(SincereLoyalty.TRIDENTS.contains(item.getItem()) && SincereLoyalty.LOYALTY_CATALYSTS.contains(upgradeItem.getItem()));
+        }
+    }
+
+    @ModifyArg(
+        method = "updateResult",
+        slice = @Slice(from = @At(value = "FIELD", target = "Lnet/minecraft/item/ItemStack;EMPTY:Lnet/minecraft/item/ItemStack;")),
+        at = @At(
+            value = "INVOKE",
+            target = "Lnet/minecraft/inventory/CraftingResultInventory;setStack(ILnet/minecraft/item/ItemStack;)V"
+        )
+    )
+    private ItemStack updateResult(ItemStack initialResult) {
+        if (initialResult.isEmpty()) {
+            ItemStack item = this.input.getStack(0);
+            ItemStack upgradeItem = this.input.getStack(1);
+            if (SincereLoyalty.TRIDENTS.contains(item.getItem()) && SincereLoyalty.LOYALTY_CATALYSTS.contains(upgradeItem.getItem())) {
+                Map<Enchantment, Integer> enchantments = EnchantmentHelper.get(item);
+                if (enchantments.getOrDefault(Enchantments.LOYALTY, 0) == Enchantments.LOYALTY.getMaxLevel()) {
+                    ItemStack result = item.copy();
+                    // we can mutate the map as it is recreated with every call to getEnchantments
+                    enchantments.put(Enchantments.LOYALTY, Enchantments.LOYALTY.getMaxLevel() + 1);
+                    EnchantmentHelper.set(enchantments, result);
+                    CompoundTag loyaltyData = result.getOrCreateSubTag(LoyalTrident.MOD_NBT_KEY);
+                    loyaltyData.putUuid(LoyalTrident.TRIDENT_OWNER_NBT_KEY, this.player.getUuid());
+                    loyaltyData.putString(LoyalTrident.OWNER_NAME_NBT_KEY, this.player.getEntityName());
+                    return result;
+                }
+            }
+        }
+        return initialResult;
+    }
+}

--- a/src/main/java/ladysnake/sincereloyalty/mixin/TridentEntityMixin.java
+++ b/src/main/java/ladysnake/sincereloyalty/mixin/TridentEntityMixin.java
@@ -1,0 +1,151 @@
+/*
+ * Sincere-Loyalty
+ * Copyright (C) 2020 Ladysnake
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; If not, see <https://www.gnu.org/licenses>.
+ */
+package ladysnake.sincereloyalty.mixin;
+
+import ladysnake.sincereloyalty.LoyalTrident;
+import ladysnake.sincereloyalty.storage.LoyalTridentStorage;
+import net.minecraft.entity.EntityType;
+import net.minecraft.entity.data.DataTracker;
+import net.minecraft.entity.data.TrackedData;
+import net.minecraft.entity.data.TrackedDataHandlerRegistry;
+import net.minecraft.entity.projectile.PersistentProjectileEntity;
+import net.minecraft.entity.projectile.TridentEntity;
+import net.minecraft.item.ItemStack;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.server.world.ServerWorld;
+import net.minecraft.world.World;
+import org.jetbrains.annotations.Nullable;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.Unique;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.ModifyVariable;
+import org.spongepowered.asm.mixin.injection.Slice;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import java.util.Objects;
+import java.util.Optional;
+import java.util.UUID;
+
+@Mixin(TridentEntity.class)
+public abstract class TridentEntityMixin extends PersistentProjectileEntity implements LoyalTrident {
+    @Shadow
+    private ItemStack tridentStack;
+    private static final TrackedData<Boolean> sincereLoyalty$SITTING = DataTracker.registerData(TridentEntity.class, TrackedDataHandlerRegistry.BOOLEAN);
+
+    private @Nullable Optional<UUID> sincereLoyalty_trueOwner;
+
+    protected TridentEntityMixin(EntityType<? extends PersistentProjectileEntity> entityType, World world) {
+        super(entityType, world);
+    }
+
+    @Inject(method = "initDataTracker", at = @At("RETURN"))
+    private void initDataTracker(CallbackInfo ci) {
+        this.getDataTracker().startTracking(sincereLoyalty$SITTING, false);
+    }
+
+    @Override
+    public UUID loyaltrident_getTridentUuid() {
+        return LoyalTrident.getTridentUuid(this.tridentStack);
+    }
+
+    @Override
+    public void loyaltrident_sit() {
+        this.getDataTracker().set(sincereLoyalty$SITTING, true);
+    }
+
+    @Override
+    public void loyaltrident_wakeUp() {
+        this.getDataTracker().set(sincereLoyalty$SITTING, false);
+    }
+
+    @Override
+    public void loyaltrident_setReturnSlot(int slot) {
+        LoyalTrident.setPreferredSlot(this.tridentStack, slot);
+    }
+
+    /**
+     * If the trident was dropped as an item, we want it to stay in place and not immediately return to its owner.
+     *
+     * <p> This redirects the loyalty check, preventing the trident from going back after it hits something,
+     * and preventing it from dropping if the owner dies.
+     */
+    @ModifyVariable(
+        method = "tick",
+        slice = @Slice(
+            from = @At(value = "FIELD", target = "Lnet/minecraft/entity/projectile/TridentEntity;LOYALTY:Lnet/minecraft/entity/data/TrackedData;"),
+            to = @At(value = "INVOKE", target = "Lnet/minecraft/entity/projectile/TridentEntity;isOwnerAlive()Z")
+        ),
+        at = @At("STORE")
+    )
+    private int sit(int loyaltyLevel) {
+        // If your owner told you to sit, you sit (fake no loyalty)
+        if (this.getDataTracker().get(sincereLoyalty$SITTING)) {
+            return 0;
+        }
+        return loyaltyLevel;
+    }
+
+    @Inject(method = "tick", at = @At("RETURN"))
+    private void tickTrident(CallbackInfo ci) {
+        if (!this.world.isClient) {
+            this.getTrueTridentOwner().ifPresent(trueOwnerUuid -> {
+                // Keep track of this trident's position at all time, in case the chunk goes unloaded
+                LoyalTridentStorage.get((ServerWorld) this.world)
+                    .memorizeTrident(trueOwnerUuid, ((TridentEntity) (Object) this));
+            });
+        }
+    }
+
+    @Unique
+    private Optional<UUID> getTrueTridentOwner() {
+        //noinspection OptionalAssignedToNull
+        if (this.sincereLoyalty_trueOwner == null) {
+            this.sincereLoyalty_trueOwner = Optional.ofNullable(LoyalTrident.getTrueOwner(this.tridentStack));
+            // Not the owner == no loyalty
+            if (this.sincereLoyalty_trueOwner.isPresent() && !sincereLoyalty_trueOwner.get().equals(((ProjectileAccessor) this).getOwnerUuid())) {
+                this.loyaltrident_sit();
+            }
+        }
+        return this.sincereLoyalty_trueOwner;
+    }
+
+    @Override
+    public void remove(RemovalReason reason) {
+        super.remove(reason);
+        if (!world.isClient && !reason.shouldSave()) {
+            this.getTrueTridentOwner().ifPresent(uuid ->
+                LoyalTridentStorage.get(((ServerWorld) this.world)).forgetTrident(uuid, ((TridentEntity) (Object) this)));
+        }
+    }
+
+    @Inject(method = "writeCustomDataToNbt", at = @At("RETURN"))
+    private void writeCustomDataToNbt(CompoundTag tag, CallbackInfo ci) {
+        if (this.getDataTracker().get(sincereLoyalty$SITTING)) {
+            tag.putBoolean(LoyalTrident.TRIDENT_SIT_NBT_KEY, true);
+        }
+    }
+
+    @Inject(method = "readCustomDataFromNbt", at = @At("RETURN"))
+    private void readCustomDataFromNbt(CompoundTag tag, CallbackInfo ci) {
+        if (tag.contains(TRIDENT_SIT_NBT_KEY)) {
+            this.getDataTracker().set(sincereLoyalty$SITTING, tag.getBoolean(TRIDENT_SIT_NBT_KEY));
+        }
+    }
+}

--- a/src/main/java/ladysnake/sincereloyalty/mixin/TridentItemMixin.java
+++ b/src/main/java/ladysnake/sincereloyalty/mixin/TridentItemMixin.java
@@ -1,0 +1,38 @@
+/*
+ * Sincere-Loyalty
+ * Copyright (C) 2020 Ladysnake
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; If not, see <https://www.gnu.org/licenses>.
+ */
+package ladysnake.sincereloyalty.mixin;
+
+import ladysnake.sincereloyalty.LoyalTrident;
+import net.minecraft.entity.LivingEntity;
+import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.entity.projectile.TridentEntity;
+import net.minecraft.item.ItemStack;
+import net.minecraft.item.TridentItem;
+import net.minecraft.world.World;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.ModifyVariable;
+
+@Mixin(TridentItem.class)
+public abstract class TridentItemMixin {
+    @ModifyVariable(method = "onStoppedUsing", at = @At(value = "INVOKE", target = "Lnet/minecraft/entity/projectile/TridentEntity;setProperties(Lnet/minecraft/entity/Entity;FFFFF)V"))
+    private TridentEntity setTridentReturnSlot(TridentEntity trident, ItemStack stack, World world, LivingEntity user) {
+        LoyalTrident.of(trident).loyaltrident_setReturnSlot(((PlayerEntity) user).getInventory().selectedSlot);
+        return trident;
+    }
+}

--- a/src/main/java/ladysnake/sincereloyalty/mixin/client/ItemStackMixin.java
+++ b/src/main/java/ladysnake/sincereloyalty/mixin/client/ItemStackMixin.java
@@ -1,0 +1,73 @@
+/*
+ * Sincere-Loyalty
+ * Copyright (C) 2020 Ladysnake
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; If not, see <https://www.gnu.org/licenses>.
+ */
+package ladysnake.sincereloyalty.mixin.client;
+
+import ladysnake.sincereloyalty.LoyalTrident;
+import net.minecraft.client.item.TooltipContext;
+import net.minecraft.enchantment.Enchantment;
+import net.minecraft.enchantment.Enchantments;
+import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.item.ItemStack;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.text.LiteralText;
+import net.minecraft.text.MutableText;
+import net.minecraft.text.Text;
+import net.minecraft.text.TranslatableText;
+import net.minecraft.util.Formatting;
+import org.jetbrains.annotations.Nullable;
+import org.spongepowered.asm.mixin.Dynamic;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.Unique;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+import java.util.List;
+
+@Mixin(ItemStack.class)
+public abstract class ItemStackMixin {
+
+    @Shadow
+    public abstract CompoundTag getSubTag(String key);
+
+    @Nullable
+    @Unique
+    private static String trueOwnerName;
+
+    @Inject(method = "getTooltip", at = @At(value = "INVOKE", target = "Lnet/minecraft/item/ItemStack;appendEnchantments(Ljava/util/List;Lnet/minecraft/nbt/ListTag;)V"))
+    private void captureThis(PlayerEntity player, TooltipContext context, CallbackInfoReturnable<List<Text>> cir) {
+        CompoundTag loyaltyNbt = this.getSubTag(LoyalTrident.MOD_NBT_KEY);
+        if (loyaltyNbt != null && loyaltyNbt.contains(LoyalTrident.OWNER_NAME_NBT_KEY)) {
+            trueOwnerName = loyaltyNbt.getString(LoyalTrident.OWNER_NAME_NBT_KEY);
+        }
+    }
+
+    // inject into the lambda in appendEnchantments
+    @Dynamic("Lambda method")
+    @Inject(method = "method_17869", at = @At("RETURN"))
+    private static void editTooltip(List<Text> lines, CompoundTag enchantmentNbt, Enchantment enchantment, CallbackInfo info) {
+        if (enchantment == Enchantments.LOYALTY && trueOwnerName != null) {
+            if (!lines.isEmpty()) {
+                ((MutableText) lines.get(lines.size() - 1)).append(new LiteralText(" ")).append(new TranslatableText("impaled:tooltip.owned_by", trueOwnerName).formatted(Formatting.DARK_GRAY));
+            }
+            trueOwnerName = null;
+        }
+    }
+}

--- a/src/main/java/ladysnake/sincereloyalty/mixin/client/MinecraftClientMixin.java
+++ b/src/main/java/ladysnake/sincereloyalty/mixin/client/MinecraftClientMixin.java
@@ -1,0 +1,37 @@
+/*
+ * Sincere-Loyalty
+ * Copyright (C) 2020 Ladysnake
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; If not, see <https://www.gnu.org/licenses>.
+ */
+package ladysnake.sincereloyalty.mixin.client;
+
+import ladysnake.sincereloyalty.SincereLoyaltyClient;
+import net.minecraft.client.MinecraftClient;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(MinecraftClient.class)
+public abstract class MinecraftClientMixin {
+    @Shadow
+    private int itemUseCooldown;
+
+    @Inject(method = "doItemUse", at = @At("TAIL"))
+    private void onUseFail(CallbackInfo ci) {
+        SincereLoyaltyClient.INSTANCE.setFailedUse(this.itemUseCooldown);
+    }
+}

--- a/src/main/java/ladysnake/sincereloyalty/mixin/client/PlayerEntityRendererMixin.java
+++ b/src/main/java/ladysnake/sincereloyalty/mixin/client/PlayerEntityRendererMixin.java
@@ -1,0 +1,39 @@
+/*
+ * Sincere-Loyalty
+ * Copyright (C) 2020 Ladysnake
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; If not, see <https://www.gnu.org/licenses>.
+ */
+package ladysnake.sincereloyalty.mixin.client;
+
+import ladysnake.sincereloyalty.TridentRecaller;
+import net.minecraft.client.network.AbstractClientPlayerEntity;
+import net.minecraft.client.render.entity.PlayerEntityRenderer;
+import net.minecraft.client.render.entity.model.BipedEntityModel;
+import net.minecraft.util.Hand;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+@Mixin(PlayerEntityRenderer.class)
+public abstract class PlayerEntityRendererMixin {
+
+    @Inject(method = "getArmPose", at = @At(value = "FIELD", target = "Lnet/minecraft/client/render/entity/model/BipedEntityModel$ArmPose;EMPTY:Lnet/minecraft/client/render/entity/model/BipedEntityModel$ArmPose;"), cancellable = true)
+    private static void getArmPose(AbstractClientPlayerEntity player, Hand hand, CallbackInfoReturnable<BipedEntityModel.ArmPose> cir) {
+        if (((TridentRecaller) player).getCurrentRecallStatus() != TridentRecaller.RecallStatus.NONE) {
+            cir.setReturnValue(BipedEntityModel.ArmPose.CROSSBOW_HOLD);
+        }
+    }
+}

--- a/src/main/java/ladysnake/sincereloyalty/storage/InventoryTridentEntry.java
+++ b/src/main/java/ladysnake/sincereloyalty/storage/InventoryTridentEntry.java
@@ -1,0 +1,73 @@
+/*
+ * Sincere-Loyalty
+ * Copyright (C) 2020 Ladysnake
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; If not, see <https://www.gnu.org/licenses>.
+ */
+package ladysnake.sincereloyalty.storage;
+
+import ladysnake.sincereloyalty.LoyalTrident;
+import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.entity.projectile.TridentEntity;
+import net.minecraft.item.ItemStack;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.server.world.ServerWorld;
+
+import java.util.UUID;
+
+public class InventoryTridentEntry extends TridentEntry {
+    private final UUID playerUuid;
+
+    InventoryTridentEntry(ServerWorld world, UUID tridentUuid, UUID playerUuid) {
+        super(world, tridentUuid);
+        this.playerUuid = playerUuid;
+    }
+
+    InventoryTridentEntry(ServerWorld world, CompoundTag tag) {
+        super(world, tag);
+        this.playerUuid = tag.getUuid("player_uuid");
+    }
+
+    @Override
+    public CompoundTag toNbt(CompoundTag nbt) {
+        super.toNbt(nbt);
+        nbt.putUuid("player_uuid", this.playerUuid);
+        return nbt;
+    }
+
+    @Override
+    public TridentEntity findTrident() {
+        PlayerEntity player = this.world.getPlayerByUuid(this.playerUuid);
+        if (player != null) {
+            for (int slot = 0; slot < player.getInventory().size(); slot++) {
+                ItemStack stack = player.getInventory().getStack(slot);
+                CompoundTag loyaltyData = stack.getSubTag(LoyalTrident.MOD_NBT_KEY);
+                if (loyaltyData != null && loyaltyData.containsUuid(LoyalTrident.TRIDENT_UUID_NBT_KEY)) {
+                    if (loyaltyData.getUuid(LoyalTrident.TRIDENT_UUID_NBT_KEY).equals(this.tridentUuid)) {
+                        TridentEntity tridentEntity = LoyalTrident.spawnTridentForStack(player, stack);
+                        if (tridentEntity != null) {
+                            player.getInventory().removeStack(slot);
+                            return tridentEntity;
+                        }
+                    }
+                }
+            }
+        }
+        return null;
+    }
+
+    public boolean isHolder(PlayerEntity holder) {
+        return this.playerUuid.equals(holder.getUuid());
+    }
+}

--- a/src/main/java/ladysnake/sincereloyalty/storage/LoyalTridentStorage.java
+++ b/src/main/java/ladysnake/sincereloyalty/storage/LoyalTridentStorage.java
@@ -1,0 +1,145 @@
+/*
+ * Sincere-Loyalty
+ * Copyright (C) 2020 Ladysnake
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; If not, see <https://www.gnu.org/licenses>.
+ */
+package ladysnake.sincereloyalty.storage;
+
+import com.google.common.base.Preconditions;
+import ladysnake.sincereloyalty.LoyalTrident;
+import ladysnake.sincereloyalty.SincereLoyalty;
+import net.fabricmc.fabric.api.util.NbtType;
+import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.entity.projectile.TridentEntity;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.nbt.ListTag;
+import net.minecraft.network.packet.s2c.play.PlaySoundIdS2CPacket;
+import net.minecraft.server.network.ServerPlayerEntity;
+import net.minecraft.server.world.ServerWorld;
+import net.minecraft.sound.SoundEvents;
+import net.minecraft.util.Identifier;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.math.Vec3d;
+import net.minecraft.world.PersistentState;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.UUID;
+
+public final class LoyalTridentStorage extends PersistentState {
+
+    public static LoyalTridentStorage get(ServerWorld world) {
+        final String id = SincereLoyalty.MOD_ID + "_trident_storage";
+        return world.getPersistentStateManager().getOrCreate(tag -> fromNbt(world, tag), () -> new LoyalTridentStorage(world), id);
+    }
+
+    /** Player UUID -> Trident UUID -> Trident Position */
+    private final Map<UUID, OwnedTridents> tridents = new HashMap<>();
+    final ServerWorld world;
+
+    public LoyalTridentStorage(ServerWorld world) {
+        super();
+        this.world = world;
+    }
+
+    public boolean hasTridents(PlayerEntity player) {
+        return !this.tridents.getOrDefault(player.getUuid(), OwnedTridents.EMPTY).isEmpty();
+    }
+
+    /**
+     * Memorizes a loyal trident that is currently existing in the world
+     */
+    public void memorizeTrident(UUID owner, TridentEntity trident) {
+        BlockPos tridentPos = trident.getBlockPos();
+        this.tridents.computeIfAbsent(owner, o -> new OwnedTridents(this)).storeTridentPosition(LoyalTrident.of(trident).loyaltrident_getTridentUuid(), trident.getUuid(), tridentPos);
+    }
+
+    /**
+     * Memorizes a loyal trident that is being held in another player's inventory
+     */
+    public void memorizeTrident(UUID owner, UUID tridentUuid, PlayerEntity holder) {
+        Preconditions.checkNotNull(owner);
+        Preconditions.checkNotNull(tridentUuid);
+        this.tridents.computeIfAbsent(owner, o -> new OwnedTridents(this)).storeTridentHolder(tridentUuid, holder);
+    }
+
+    public void forgetTrident(UUID owner, TridentEntity trident) {
+        this.tridents.getOrDefault(owner, OwnedTridents.EMPTY).clearTridentPosition(LoyalTrident.of(trident).loyaltrident_getTridentUuid());
+    }
+
+    /**
+     * @return {@code true} if at least one trident was recalled
+     */
+    public boolean recallTridents(PlayerEntity player) {
+        boolean foundAny = false;
+        for (Iterator<TridentEntry> it = this.tridents.getOrDefault(player.getUuid(), OwnedTridents.EMPTY).iterator(); it.hasNext(); ) {
+            TridentEntity trident = it.next().findTrident();
+
+            if (trident == null) {
+                it.remove();
+                continue;
+            }
+
+            float initialDistance = trident.distanceTo(player);
+            ((LoyalTrident) trident).loyaltrident_wakeUp();
+
+            if (initialDistance > 64) {
+                // reposition the trident at the same angle to the player but only 64 blocks away
+                Vec3d newPos = player.getPos().add(trident.getPos().subtract(player.getPos()).normalize().multiply(64));
+                trident.refreshPositionAfterTeleport(newPos);
+            }
+
+            ((LoyalTrident) trident).loyaltrident_setReturnSlot(player.getInventory().selectedSlot);
+            this.world.playSound(player, trident.getX(), trident.getY(), trident.getZ(), SoundEvents.ITEM_TRIDENT_RETURN, trident.getSoundCategory(), 2.0f, 0.7f);
+            ((ServerPlayerEntity) player).networkHandler.connection.send(new PlaySoundIdS2CPacket(new Identifier("item.trident.return"), trident.getSoundCategory(), trident.getPos(), trident.distanceTo(player) / 8, 0.7f));
+            foundAny = true;
+        }
+        return foundAny;
+    }
+
+    public static LoyalTridentStorage fromNbt(ServerWorld world, CompoundTag tag) {
+        LoyalTridentStorage ret = new LoyalTridentStorage(world);
+        ListTag ownersNbt = tag.getList("trident_owners", NbtType.COMPOUND);
+        for (int i = 0; i < ownersNbt.size(); i++) {
+            OwnedTridents tridents = new OwnedTridents(ret);
+            CompoundTag ownerNbt = ownersNbt.getCompound(i);
+            UUID ownerUuid = ownerNbt.getUuid("owner_uuid");
+            tridents.fromTag(ownerNbt);
+            ret.tridents.put(ownerUuid, tridents);
+        }
+        return ret;
+    }
+
+    @NotNull
+    @Override
+    public CompoundTag writeNbt(CompoundTag tag) {
+        if (!this.tridents.isEmpty()) {
+            ListTag ownersNbt = new ListTag();
+            this.tridents.forEach((ownerUuid, tridents) -> {
+                if (!tridents.isEmpty()) {
+                    CompoundTag ownerNbt = new CompoundTag();
+                    ownerNbt.putUuid("owner_uuid", ownerUuid);
+                    tridents.toTag(ownerNbt);
+                    ownersNbt.add(ownerNbt);
+                }
+            });
+            tag.put("trident_owners", ownersNbt);
+        }
+        return tag;
+    }
+
+}

--- a/src/main/java/ladysnake/sincereloyalty/storage/OwnedTridents.java
+++ b/src/main/java/ladysnake/sincereloyalty/storage/OwnedTridents.java
@@ -1,0 +1,96 @@
+/*
+ * Sincere-Loyalty
+ * Copyright (C) 2020 Ladysnake
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; If not, see <https://www.gnu.org/licenses>.
+ */
+package ladysnake.sincereloyalty.storage;
+
+import net.fabricmc.fabric.api.util.NbtType;
+import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.nbt.ListTag;
+import net.minecraft.util.math.BlockPos;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.*;
+
+public final class OwnedTridents implements Iterable<TridentEntry> {
+    static final OwnedTridents EMPTY = new OwnedTridents();
+
+    private final LoyalTridentStorage parentStorage;
+    private final Map<UUID, TridentEntry> ownedTridents;
+
+    private OwnedTridents() {
+        this.parentStorage = null;
+        this.ownedTridents = Collections.emptyMap();
+    }
+
+    OwnedTridents(LoyalTridentStorage parentStorage) {
+        this.parentStorage = parentStorage;
+        this.ownedTridents = new HashMap<>();
+    }
+
+    public void storeTridentPosition(UUID tridentUuid, UUID tridentEntityUuid, BlockPos lastPos) {
+        TridentEntry entry = this.ownedTridents.get(tridentUuid);
+        if (entry instanceof WorldTridentEntry) {
+            ((WorldTridentEntry) entry).updateLastPos(tridentEntityUuid, lastPos);
+        } else {
+            this.ownedTridents.put(tridentUuid, new WorldTridentEntry(this.parentStorage.world, tridentUuid, tridentUuid, lastPos));
+        }
+    }
+
+    public void storeTridentHolder(UUID tridentUuid, PlayerEntity holder) {
+        TridentEntry entry = this.ownedTridents.get(tridentUuid);
+        if (!(entry instanceof InventoryTridentEntry) || !((InventoryTridentEntry) entry).isHolder(holder)) {
+            this.addEntry(new InventoryTridentEntry(this.parentStorage.world, tridentUuid, holder.getUuid()));
+        }
+    }
+
+    private void addEntry(@NotNull TridentEntry entry) {
+        this.ownedTridents.put(entry.getTridentUuid(), entry);
+    }
+
+    public void clearTridentPosition(UUID tridentUuid) {
+        this.ownedTridents.remove(tridentUuid);
+    }
+
+    @NotNull
+    @Override
+    public Iterator<TridentEntry> iterator() {
+        return this.ownedTridents.values().iterator();
+    }
+
+    public boolean isEmpty() {
+        return this.ownedTridents.isEmpty();
+    }
+
+    public void fromTag(CompoundTag ownerNbt) {
+        ListTag tridentsNbt = ownerNbt.getList("tridents", NbtType.COMPOUND);
+        for (int j = 0; j < tridentsNbt.size(); j++) {
+            TridentEntry trident = TridentEntry.fromNbt(this.parentStorage.world, tridentsNbt.getCompound(j));
+            if (trident != null) {
+                this.addEntry(trident);
+            }
+        }
+    }
+
+    public void toTag(CompoundTag ownerNbt) {
+        ListTag tridentsNbt = new ListTag();
+        for (TridentEntry trident : this.ownedTridents.values()) {
+            tridentsNbt.add(trident.toNbt(new CompoundTag()));
+        }
+        ownerNbt.put("tridents", tridentsNbt);
+    }
+}

--- a/src/main/java/ladysnake/sincereloyalty/storage/TridentEntry.java
+++ b/src/main/java/ladysnake/sincereloyalty/storage/TridentEntry.java
@@ -1,0 +1,65 @@
+/*
+ * Sincere-Loyalty
+ * Copyright (C) 2020 Ladysnake
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; If not, see <https://www.gnu.org/licenses>.
+ */
+package ladysnake.sincereloyalty.storage;
+
+import net.minecraft.entity.projectile.TridentEntity;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.server.world.ServerWorld;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.UUID;
+
+public abstract class TridentEntry {
+    @Nullable
+    public static TridentEntry fromNbt(ServerWorld world, CompoundTag tag) {
+        try {
+            switch (tag.getString("type")) {
+                case "world": return new WorldTridentEntry(world, tag);
+                case "inventory": return new InventoryTridentEntry(world, tag);
+                default: // pass
+            }
+        } catch (IllegalArgumentException e) {
+            e.printStackTrace();
+        }
+        return null;
+    }
+
+    protected final ServerWorld world;
+    protected final UUID tridentUuid;
+
+    TridentEntry(ServerWorld world, UUID tridentUuid) {
+        this.world = world;
+        this.tridentUuid = tridentUuid;
+    }
+
+    TridentEntry(ServerWorld world, CompoundTag nbt) {
+        this(world, nbt.getUuid("trident_uuid"));
+    }
+
+    public UUID getTridentUuid() {
+        return tridentUuid;
+    }
+
+    @Nullable
+    public abstract TridentEntity findTrident();
+
+    public CompoundTag toNbt(CompoundTag nbt) {
+        nbt.putUuid("trident_uuid", this.tridentUuid);
+        return nbt;
+    }
+}

--- a/src/main/java/ladysnake/sincereloyalty/storage/WorldTridentEntry.java
+++ b/src/main/java/ladysnake/sincereloyalty/storage/WorldTridentEntry.java
@@ -1,0 +1,69 @@
+/*
+ * Sincere-Loyalty
+ * Copyright (C) 2020 Ladysnake
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; If not, see <https://www.gnu.org/licenses>.
+ */
+package ladysnake.sincereloyalty.storage;
+
+import net.minecraft.entity.Entity;
+import net.minecraft.entity.projectile.TridentEntity;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.nbt.NbtHelper;
+import net.minecraft.server.world.ServerWorld;
+import net.minecraft.util.math.BlockPos;
+
+import java.util.UUID;
+
+public final class WorldTridentEntry extends TridentEntry {
+    private UUID tridentEntityUuid;
+    private BlockPos lastPos;
+
+    public WorldTridentEntry(ServerWorld world, UUID tridentUuid, UUID tridentEntityUuid, BlockPos lastPos) {
+        super(world, tridentUuid);
+        this.tridentEntityUuid = tridentEntityUuid;
+        this.lastPos = lastPos;
+    }
+
+    public WorldTridentEntry(ServerWorld world, CompoundTag tag) {
+        super(world, tag);
+        this.tridentEntityUuid = tag.getUuid("trident_entity_uuid");
+        this.lastPos = NbtHelper.toBlockPos(tag.getCompound("last_pos"));
+    }
+
+    @Override
+    public CompoundTag toNbt(CompoundTag nbt) {
+        super.toNbt(nbt);
+        nbt.putUuid("trident_entity_uuid", this.tridentEntityUuid);
+        nbt.put("last_pos", NbtHelper.fromBlockPos(this.lastPos));
+        return nbt;
+    }
+
+    public void updateLastPos(UUID tridentEntityUuid, BlockPos pos) {
+        this.tridentEntityUuid = tridentEntityUuid;
+        this.lastPos = pos;
+    }
+
+    @Override
+    public TridentEntity findTrident() {
+        // preload the chunk
+        this.world.getChunk(this.lastPos);
+        Entity trident = this.world.getEntity(this.tridentEntityUuid);
+        if (trident instanceof TridentEntity) {
+            return (TridentEntity) trident;
+        }
+        return null;
+    }
+
+}

--- a/src/main/resources/assets/impaled/lang/en_us.json
+++ b/src/main/resources/assets/impaled/lang/en_us.json
@@ -2,5 +2,8 @@
   "item.impaled.pitchfork": "Pitchfork",
   "item.impaled.hellfork": "Hellfork",
   "item.impaled.elder_trident": "Elder Trident",
-  "enchantment.impaled.kindling_curse": "Curse of Kindling"
+  "enchantment.impaled.kindling_curse": "Curse of Kindling",
+
+  "impaled:tooltip.owned_by": "(to %s)",
+  "impaled:trident_recall_fail": "Failed to recall your tridents"
 }

--- a/src/main/resources/assets/impaled/lang/fr_fr.json
+++ b/src/main/resources/assets/impaled/lang/fr_fr.json
@@ -1,0 +1,4 @@
+{
+  "impaled:tooltip.owned_by": "(envers %s)",
+  "impaled:trident_recall_fail": "Le rappel de vos tridents a échoué"
+}

--- a/src/main/resources/data/impaled/tags/items/loyalty_catalysts.json
+++ b/src/main/resources/data/impaled/tags/items/loyalty_catalysts.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "minecraft:heart_of_the_sea"
+  ]
+}

--- a/src/main/resources/data/impaled/tags/items/tridents.json
+++ b/src/main/resources/data/impaled/tags/items/tridents.json
@@ -1,0 +1,9 @@
+{
+  "replace": false,
+  "values": [
+    "minecraft:trident",
+    "impaled:pitchfork",
+    "impaled:hellfork",
+    "impaled:elder_trident"
+  ]
+}

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -21,14 +21,17 @@
   "environment": "client",
   "entrypoints": {
     "main": [
-      "ladysnake.impaled.common.Impaled"
+      "ladysnake.impaled.common.Impaled",
+      "ladysnake.sincereloyalty.SincereLoyalty"
     ],
     "client": [
-      "ladysnake.impaled.client.ImpaledClient"
+      "ladysnake.impaled.client.ImpaledClient",
+      "ladysnake.sincereloyalty.SincereLoyaltyClient::INSTANCE"
     ]
   },
   "mixins": [
-    "impaled.mixins.json"
+    "impaled.mixins.json",
+    "sincereloyalty.mixins.json"
   ],
 
   "depends": {

--- a/src/main/resources/sincereloyalty.mixins.json
+++ b/src/main/resources/sincereloyalty.mixins.json
@@ -1,0 +1,25 @@
+{
+  "required": true,
+  "package": "ladysnake.sincereloyalty.mixin",
+  "compatibilityLevel": "JAVA_8",
+  "minVersion": "0.7.11-SNAPSHOT",
+  "mixins": [
+    "ItemEntityMixin",
+    "ItemMixin",
+    "PlayerEntityMixin",
+    "PlayerInventoryMixin",
+    "ProjectileAccessor",
+    "ServerPlayNetworkHandlerMixin",
+    "SmithingScreenHandlerMixin",
+    "TridentEntityMixin",
+    "TridentItemMixin"
+  ],
+  "client": [
+    "client.ItemStackMixin",
+    "client.MinecraftClientMixin",
+    "client.PlayerEntityRendererMixin"
+  ],
+  "injectors": {
+    "defaultRequire": 1
+  }
+}


### PR DESCRIPTION
Make your trident even more loyal !

A trident with Loyalty III can be combined with Heart of the Sea to obtain Loyalty IV.

![Craft](https://cdn.discordapp.com/attachments/523251999899385875/686333307947974707/unknown.png)

At this level, whenever it is dropped it will drop as an entity. Tridents abandoned in this way can be brought back to you
by keeping right click down with an empty hand, no matter the distance. No one will be able to steal them from you for long either, as Loyalty IV tridents can always be recalled by you when thrown or dropped. Tridents with Loyalty IV cannot be destroyed by normal means.

Also it works with Impaled tridents.