### PR TITLE
Change how Impaling works

### DIFF
--- a/src/main/java/ladysnake/impaled/common/enchantment/BetterImpaling.java
+++ b/src/main/java/ladysnake/impaled/common/enchantment/BetterImpaling.java
@@ -1,0 +1,33 @@
+package ladysnake.impaled.common.enchantment;
+
+import ladysnake.impaled.common.init.ImpaledItems;
+import net.minecraft.enchantment.EnchantmentHelper;
+import net.minecraft.enchantment.Enchantments;
+import net.minecraft.entity.Entity;
+import net.minecraft.entity.LivingEntity;
+import net.minecraft.entity.effect.StatusEffects;
+import net.minecraft.item.ItemStack;
+
+public final class BetterImpaling {
+    public static float getAttackDamage(ItemStack stack, Entity target) {
+        int impalingLevel = EnchantmentHelper.getLevel(Enchantments.IMPALING, stack);
+
+        if (impalingLevel > 0) {
+            if (stack.getItem() == ImpaledItems.HELLFORK) {
+                if (isFireImmune(target)) {
+                    return impalingLevel * 2F;
+                }
+            } else if (target.isWet()) {
+                return impalingLevel * 1.5F;
+            }
+        }
+
+        return 0;
+    }
+
+    private static boolean isFireImmune(Entity target) {
+        if (target.isFireImmune()) return true;
+        if (!(target instanceof LivingEntity)) return false;
+        return ((LivingEntity) target).hasStatusEffect(StatusEffects.FIRE_RESISTANCE);
+    }
+}

--- a/src/main/java/ladysnake/impaled/mixin/impaling/ImpalingEnchantmentMixin.java
+++ b/src/main/java/ladysnake/impaled/mixin/impaling/ImpalingEnchantmentMixin.java
@@ -1,0 +1,19 @@
+package ladysnake.impaled.mixin.impaling;
+
+import ladysnake.impaled.common.enchantment.BetterImpaling;
+import net.minecraft.enchantment.ImpalingEnchantment;
+import net.minecraft.entity.EntityGroup;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Overwrite;
+
+@Mixin(ImpalingEnchantment.class)
+public abstract class ImpalingEnchantmentMixin {
+    /**
+     * @reason we are canceling the vanilla effect and replacing it with our own in {@link BetterImpaling}
+     * @author Pyrofab
+     */
+    @Overwrite
+    public float getAttackDamage(int level, EntityGroup group) {
+        return 0.0F;
+    }
+}

--- a/src/main/java/ladysnake/impaled/mixin/impaling/MobEntityMixin.java
+++ b/src/main/java/ladysnake/impaled/mixin/impaling/MobEntityMixin.java
@@ -1,0 +1,32 @@
+package ladysnake.impaled.mixin.impaling;
+
+import ladysnake.impaled.common.enchantment.BetterImpaling;
+import net.minecraft.entity.Entity;
+import net.minecraft.entity.EntityType;
+import net.minecraft.entity.LivingEntity;
+import net.minecraft.entity.mob.MobEntity;
+import net.minecraft.world.World;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.ModifyVariable;
+import org.spongepowered.asm.mixin.injection.Slice;
+
+@Mixin(MobEntity.class)
+public abstract class MobEntityMixin extends LivingEntity {
+    protected MobEntityMixin(EntityType<? extends LivingEntity> entityType, World world) {
+        super(entityType, world);
+    }
+
+    @ModifyVariable(
+            method = "tryAttack",
+            slice = @Slice(
+                    from = @At("HEAD"),
+                    to = @At(value = "FIELD", target = "Lnet/minecraft/entity/attribute/EntityAttributes;GENERIC_ATTACK_KNOCKBACK:Lnet/minecraft/entity/attribute/EntityAttribute;")
+            ),
+            at = @At(value = "STORE", ordinal = 0),
+            ordinal = 0
+    )
+    private float getAttackDamage(float baseDamage, Entity target) {
+        return baseDamage + BetterImpaling.getAttackDamage(this.getMainHandStack(), target);
+    }
+}

--- a/src/main/java/ladysnake/impaled/mixin/impaling/PlayerEntityMixin.java
+++ b/src/main/java/ladysnake/impaled/mixin/impaling/PlayerEntityMixin.java
@@ -1,0 +1,23 @@
+package ladysnake.impaled.mixin.impaling;
+
+import ladysnake.impaled.common.enchantment.BetterImpaling;
+import net.minecraft.entity.Entity;
+import net.minecraft.entity.EntityType;
+import net.minecraft.entity.LivingEntity;
+import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.world.World;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.ModifyVariable;
+
+@Mixin(PlayerEntity.class)
+public abstract class PlayerEntityMixin extends LivingEntity {
+    protected PlayerEntityMixin(EntityType<? extends LivingEntity> entityType, World world) {
+        super(entityType, world);
+    }
+
+    @ModifyVariable(method = "attack", at = @At(value = "INVOKE_ASSIGN", target = "Lnet/minecraft/enchantment/EnchantmentHelper;getAttackDamage(Lnet/minecraft/item/ItemStack;Lnet/minecraft/entity/EntityGroup;)F"), ordinal = 1)
+    private float getAttackDamage(float baseDamage, Entity target) {
+        return baseDamage + BetterImpaling.getAttackDamage(this.getMainHandStack(), target);
+    }
+}

--- a/src/main/java/ladysnake/impaled/mixin/impaling/TridentEntityMixin.java
+++ b/src/main/java/ladysnake/impaled/mixin/impaling/TridentEntityMixin.java
@@ -1,0 +1,29 @@
+package ladysnake.impaled.mixin.impaling;
+
+import ladysnake.impaled.common.enchantment.BetterImpaling;
+import net.minecraft.entity.projectile.TridentEntity;
+import net.minecraft.item.ItemStack;
+import net.minecraft.util.hit.EntityHitResult;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.ModifyVariable;
+import org.spongepowered.asm.mixin.injection.Slice;
+
+@Mixin(TridentEntity.class)
+public abstract class TridentEntityMixin {
+    @Shadow private ItemStack tridentStack;
+
+    @ModifyVariable(
+            method = "onEntityHit",
+            slice = @Slice(
+                    from = @At(value = "INVOKE", target = "Lnet/minecraft/util/hit/EntityHitResult;getEntity()Lnet/minecraft/entity/Entity;"),
+                    to = @At(value = "INVOKE", target = "Lnet/minecraft/enchantment/EnchantmentHelper;getAttackDamage(Lnet/minecraft/item/ItemStack;Lnet/minecraft/entity/EntityGroup;)F")
+            ),
+            at = @At(value = "STORE", ordinal = 0),
+            ordinal = 0
+    )
+    private float getAttackDamage(float baseDamage, EntityHitResult result) {
+        return baseDamage + BetterImpaling.getAttackDamage(this.tridentStack, result.getEntity());
+    }
+}

--- a/src/main/resources/impaled.mixins.json
+++ b/src/main/resources/impaled.mixins.json
@@ -5,9 +5,13 @@
   "client": [
   ],
   "mixins": [
+    "EntityMixin",
     "TridentEntityAccessor",
     "TridentRiptideFeatureRendererMixin",
-    "EntityMixin"
+    "impaling.ImpalingEnchantmentMixin",
+    "impaling.MobEntityMixin",
+    "impaling.PlayerEntityMixin",
+    "impaling.TridentEntityMixin"
   ],
   "injectors": {
     "defaultRequire": 1


### PR DESCRIPTION
![Changelog](https://cdn.discordapp.com/attachments/477596494837448704/824306673954193448/unknown.png)

To compensate for this, Impaling only adds 0.75 heart of damage per level instead of 1.25.

On a Hellfork, it instead adds 1 heart of damage per level to all fire immune entities.