### PR TITLE
Add support for Soul Fire'd and fix a bug

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-	id 'fabric-loom' version "1.4-SNAPSHOT"
+	id 'fabric-loom' version "1.5-SNAPSHOT"
 	id 'io.github.ladysnake.chenille' version '0.11.3'
 }
 
@@ -58,6 +58,16 @@ repositories {
 	maven { url "https://maven.willbl.dev/releases" }
 	// bookshelf
 	maven { url 'https://maven.blamejared.com' }
+  // Soul Fire'd
+  maven {
+    name = "Crystal Nest"
+    url = "https://maven.crystalnest.it"
+  }
+  // FCAP for Soul Fire'd.
+  maven {
+    name = "Fuzs Mod Resources"
+    url = "https://raw.githubusercontent.com/Fuzss/modresources/main/maven/"
+  }
 }
 
 dependencies {
@@ -82,6 +92,8 @@ dependencies {
 	modRuntimeOnly(libs.bundles.enchancement) {
 		exclude group: "net.fabricmc.fabric-api"
 	}
+
+  modImplementation "it.crystalnest:soul-fire-d-fabric:${project.minecraft_version}-${soul_fire_d_version}"
 }
 
 processResources {

--- a/gradle.properties
+++ b/gradle.properties
@@ -18,6 +18,7 @@ archives_base_name = impaled
 findbugs_version = 3.0.2
 jb_annotations_version = 15.0
 apiguardian_version = 1.0.0
+soul_fire_d_version = 4.0.0
 
 #Publishing
 owners = Ladysnake

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.5-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.8-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/src/main/java/org/ladysnake/impaled/common/Impaled.java
+++ b/src/main/java/org/ladysnake/impaled/common/Impaled.java
@@ -27,13 +27,13 @@ public class Impaled implements ModInitializer {
 
         // add loot to dungeons, mineshafts, jungle temples, and stronghold libraries chests loot tables
         UniformLootNumberProvider lootTableRange = UniformLootNumberProvider.create(1, 1);
-        LootCondition chanceLootCondition = RandomChanceLootCondition.builder(60).build();
+        LootCondition.Builder chanceLootCondition = RandomChanceLootCondition.builder(60);
         LootTableEvents.MODIFY.register((resourceManager, lootManager, id, supplier, setter) -> {
             if (BASTION_TREASURE_CHEST_LOOT_TABLE_ID.equals(id)) {
-                LootPool lootPool = LootPool.builder()
+                LootPool.Builder lootPool = LootPool.builder()
                         .rolls(lootTableRange)
                         .conditionally(chanceLootCondition)
-                        .with(ItemEntry.builder(ImpaledItems.ANCIENT_TRIDENT).build()).build();
+                        .with(ItemEntry.builder(ImpaledItems.ANCIENT_TRIDENT));
 
                 supplier.pool(lootPool);
             }

--- a/src/main/java/org/ladysnake/impaled/common/entity/FireTridentEntity.java
+++ b/src/main/java/org/ladysnake/impaled/common/entity/FireTridentEntity.java
@@ -1,0 +1,50 @@
+package org.ladysnake.impaled.common.entity;
+
+import net.minecraft.entity.Entity;
+import net.minecraft.entity.EntityType;
+import net.minecraft.entity.LivingEntity;
+import net.minecraft.particle.ParticleTypes;
+import net.minecraft.util.hit.EntityHitResult;
+import net.minecraft.world.World;
+
+public abstract class FireTridentEntity extends ImpaledTridentEntity {
+    public FireTridentEntity(EntityType<? extends FireTridentEntity> entityType, World world) {
+        super(entityType, world);
+    }
+
+    @Override
+    protected void onEntityHit(EntityHitResult entityHitResult) {
+        Entity entity = entityHitResult.getEntity();
+        if (entity instanceof LivingEntity livingEntity && livingEntity.getType() != EntityType.ENDERMAN) {
+            setTargetOnFireFor(livingEntity, 1);
+            super.onEntityHit(entityHitResult);
+        }
+    }
+
+    @Override
+    protected void onHit(LivingEntity target) {
+        super.onHit(target);
+        setTargetOnFireFor(target, 8);
+    }
+
+    @Override
+    public boolean isOnFire() {
+        return true;
+    }
+
+    @Override
+    public boolean doesRenderOnFire() {
+        return false;
+    }
+
+    @Override
+    public void tick() {
+        super.tick();
+
+        if (this.isSubmergedInWater() && this.getWorld().isClient() && this.random.nextInt(5) == 0) {
+            this.getWorld().addParticle(ParticleTypes.BUBBLE_COLUMN_UP, this.getX() + random.nextGaussian() / 10, this.getY() + random.nextGaussian() / 10, this.getZ() + random.nextGaussian() / 10, 0, this.random.nextFloat(), 0);
+        }
+    }
+
+    protected abstract void setTargetOnFireFor(LivingEntity target, int seconds);
+}

--- a/src/main/java/org/ladysnake/impaled/common/entity/FireTridentEntity.java
+++ b/src/main/java/org/ladysnake/impaled/common/entity/FireTridentEntity.java
@@ -1,6 +1,5 @@
 package org.ladysnake.impaled.common.entity;
 
-import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityType;
 import net.minecraft.entity.LivingEntity;
 import net.minecraft.particle.ParticleTypes;
@@ -14,11 +13,10 @@ public abstract class FireTridentEntity extends ImpaledTridentEntity {
 
     @Override
     protected void onEntityHit(EntityHitResult entityHitResult) {
-        Entity entity = entityHitResult.getEntity();
-        if (entity instanceof LivingEntity livingEntity && livingEntity.getType() != EntityType.ENDERMAN) {
+        if (entityHitResult.getEntity() instanceof LivingEntity livingEntity && livingEntity.getType() != EntityType.ENDERMAN) {
             setTargetOnFireFor(livingEntity, 1);
-            super.onEntityHit(entityHitResult);
         }
+        super.onEntityHit(entityHitResult);
     }
 
     @Override

--- a/src/main/java/org/ladysnake/impaled/common/entity/HellforkEntity.java
+++ b/src/main/java/org/ladysnake/impaled/common/entity/HellforkEntity.java
@@ -10,12 +10,6 @@ public class HellforkEntity extends FireTridentEntity {
     }
 
     @Override
-    protected void onHit(LivingEntity target) {
-        super.onHit(target);
-        target.setOnFireFor(8);
-    }
-
-    @Override
     protected void setTargetOnFireFor(LivingEntity target, int seconds) {
         target.setOnFireFor(seconds);
     }

--- a/src/main/java/org/ladysnake/impaled/common/entity/HellforkEntity.java
+++ b/src/main/java/org/ladysnake/impaled/common/entity/HellforkEntity.java
@@ -2,10 +2,9 @@ package org.ladysnake.impaled.common.entity;
 
 import net.minecraft.entity.EntityType;
 import net.minecraft.entity.LivingEntity;
-import net.minecraft.particle.ParticleTypes;
 import net.minecraft.world.World;
 
-public class HellforkEntity extends ImpaledTridentEntity {
+public class HellforkEntity extends FireTridentEntity {
     public HellforkEntity(EntityType<? extends HellforkEntity> entityType, World world) {
         super(entityType, world);
     }
@@ -17,21 +16,7 @@ public class HellforkEntity extends ImpaledTridentEntity {
     }
 
     @Override
-    public boolean isOnFire() {
-        return true;
-    }
-
-    @Override
-    public boolean doesRenderOnFire() {
-        return false;
-    }
-
-    @Override
-    public void tick() {
-        super.tick();
-
-        if (this.isSubmergedInWater() && this.getWorld().isClient() && this.random.nextInt(5) == 0) {
-            this.getWorld().addParticle(ParticleTypes.BUBBLE_COLUMN_UP, this.getX() + random.nextGaussian() / 10, this.getY() + random.nextGaussian() / 10, this.getZ() + random.nextGaussian() / 10, 0, this.random.nextFloat(), 0);
-        }
+    protected void setTargetOnFireFor(LivingEntity target, int seconds) {
+        target.setOnFireFor(seconds);
     }
 }

--- a/src/main/java/org/ladysnake/impaled/common/entity/SoulforkEntity.java
+++ b/src/main/java/org/ladysnake/impaled/common/entity/SoulforkEntity.java
@@ -1,37 +1,22 @@
 package org.ladysnake.impaled.common.entity;
 
+import net.fabricmc.loader.api.FabricLoader;
 import net.minecraft.entity.EntityType;
 import net.minecraft.entity.LivingEntity;
-import net.minecraft.particle.ParticleTypes;
 import net.minecraft.world.World;
+import org.ladysnake.impaled.compat.SoulFired;
 
-public class SoulforkEntity extends ImpaledTridentEntity {
+public class SoulforkEntity extends FireTridentEntity {
     public SoulforkEntity(EntityType<? extends SoulforkEntity> entityType, World world) {
         super(entityType, world);
     }
 
     @Override
-    protected void onHit(LivingEntity target) {
-        super.onHit(target);
-        target.setOnFireFor(8);
-    }
-
-    @Override
-    public boolean isOnFire() {
-        return true;
-    }
-
-    @Override
-    public boolean doesRenderOnFire() {
-        return false;
-    }
-
-    @Override
-    public void tick() {
-        super.tick();
-
-        if (this.isSubmergedInWater() && this.getWorld().isClient() && this.random.nextInt(5) == 0) {
-            this.getWorld().addParticle(ParticleTypes.BUBBLE_COLUMN_UP, this.getX() + random.nextGaussian() / 10, this.getY() + random.nextGaussian() / 10, this.getZ() + random.nextGaussian() / 10, 0, this.random.nextFloat(), 0);
+    protected void setTargetOnFireFor(LivingEntity target, int seconds) {
+        if (FabricLoader.getInstance().isModLoaded("soul_fire_d")) {
+            SoulFired.setOnSoulFireFor(target, seconds);
+        } else {
+            target.setOnFireFor(seconds);
         }
     }
 }

--- a/src/main/java/org/ladysnake/impaled/common/init/ImpaledItems.java
+++ b/src/main/java/org/ladysnake/impaled/common/init/ImpaledItems.java
@@ -34,8 +34,8 @@ public class ImpaledItems {
     public static final Item ELDER_GUARDIAN_EYE = new Item((new Item.Settings()).rarity(Rarity.UNCOMMON));
     public static final Item ANCIENT_TRIDENT = new Item((new Item.Settings()).rarity(Rarity.UNCOMMON).fireproof());
     public static final PitchforkItem PITCHFORK = new PitchforkItem((new Item.Settings()).maxDamage(150), ImpaledEntityTypes.PITCHFORK);
-    public static final HellforkItem HELLFORK = new HellforkItem((new Item.Settings()).maxDamage(325).fireproof().fireproof(), ImpaledEntityTypes.HELLFORK);
-    public static final HellforkItem SOULFORK = new HellforkItem((new Item.Settings()).maxDamage(325).fireproof().fireproof(), ImpaledEntityTypes.SOULFORK);
+    public static final HellforkItem HELLFORK = new HellforkItem((new Item.Settings()).maxDamage(325).fireproof(), ImpaledEntityTypes.HELLFORK);
+    public static final HellforkItem SOULFORK = new HellforkItem((new Item.Settings()).maxDamage(325).fireproof(), ImpaledEntityTypes.SOULFORK);
     public static final ElderTridentItem ELDER_TRIDENT = new ElderTridentItem((new Item.Settings()).maxDamage(250), ImpaledEntityTypes.ELDER_TRIDENT);
     public static final AtlanItem ATLAN = new AtlanItem((new Item.Settings()).maxDamage(250), ImpaledEntityTypes.ATLAN);
     public static final MaelstromItem MAELSTROM = new MaelstromItem((new Item.Settings()).maxDamage(80));

--- a/src/main/java/org/ladysnake/impaled/common/item/HellforkItem.java
+++ b/src/main/java/org/ladysnake/impaled/common/item/HellforkItem.java
@@ -1,5 +1,6 @@
 package org.ladysnake.impaled.common.item;
 
+import net.fabricmc.loader.api.FabricLoader;
 import net.minecraft.block.BlockState;
 import net.minecraft.block.Blocks;
 import net.minecraft.enchantment.EnchantmentHelper;
@@ -17,6 +18,7 @@ import net.minecraft.util.ActionResult;
 import net.minecraft.util.Hand;
 import net.minecraft.util.TypedActionResult;
 import net.minecraft.world.World;
+import org.ladysnake.impaled.compat.SoulFired;
 import org.ladysnake.impaled.common.entity.ImpaledTridentEntity;
 import org.ladysnake.impaled.common.init.ImpaledItems;
 
@@ -27,7 +29,12 @@ public class HellforkItem extends ImpaledTridentItem {
 
     @Override
     public boolean postHit(ItemStack stack, LivingEntity target, LivingEntity attacker) {
-        target.setOnFireFor(4 + attacker.getRandom().nextInt(4));
+        int seconds = 4 + attacker.getRandom().nextInt(4);
+        if (this == ImpaledItems.SOULFORK && FabricLoader.getInstance().isModLoaded("soul_fire_d")) {
+            SoulFired.setOnSoulFireFor(target, seconds);
+        } else {
+            target.setOnFireFor(seconds);
+        }
         return super.postHit(stack, target, attacker);
     }
 

--- a/src/main/java/org/ladysnake/impaled/compat/SoulFired.java
+++ b/src/main/java/org/ladysnake/impaled/compat/SoulFired.java
@@ -1,0 +1,12 @@
+package org.ladysnake.impaled.compat;
+
+import it.crystalnest.soul_fire_d.api.FireManager;
+import net.minecraft.entity.Entity;
+
+public final class SoulFired {
+    private SoulFired() {}
+
+    public static void setOnSoulFireFor(Entity entity, int seconds) {
+        FireManager.setOnFire(entity, seconds, FireManager.SOUL_FIRE_TYPE);
+    }
+}

--- a/src/main/java/org/ladysnake/impaled/mixin/impaling/PlayerEntityMixin.java
+++ b/src/main/java/org/ladysnake/impaled/mixin/impaling/PlayerEntityMixin.java
@@ -6,9 +6,13 @@ import net.minecraft.entity.LivingEntity;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.world.World;
 import org.ladysnake.impaled.common.enchantment.BetterImpaling;
+import org.ladysnake.impaled.common.item.HellforkItem;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Constant;
+import org.spongepowered.asm.mixin.injection.ModifyConstant;
 import org.spongepowered.asm.mixin.injection.ModifyVariable;
+import org.spongepowered.asm.mixin.injection.Slice;
 
 @Mixin(PlayerEntity.class)
 public abstract class PlayerEntityMixin extends LivingEntity {
@@ -21,4 +25,8 @@ public abstract class PlayerEntityMixin extends LivingEntity {
         return baseDamage + BetterImpaling.getAttackDamage(this.getMainHandStack(), target);
     }
 
+    @ModifyConstant(method = "attack", constant = @Constant(expandZeroConditions = Constant.Condition.GREATER_THAN_ZERO), slice = @Slice(from = @At(value = "INVOKE_ASSIGN", target = "Lnet/minecraft/enchantment/EnchantmentHelper;getFireAspect(Lnet/minecraft/entity/LivingEntity;)I", ordinal = 0)))
+    private int checkFireDamage(int constant) {
+        return this.getMainHandStack().getItem() instanceof HellforkItem ? -1 : constant;
+    }
 }

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -35,6 +35,9 @@
     "java": ">=17",
     "fabric": ">=0.48.0"
   },
+  "suggests": {
+    "soul_fire_d": "^4.0.0"
+  },
   "custom": {
     "loom:injected_interfaces": {
       "net/minecraft/class_8109": [


### PR DESCRIPTION
This PR main focus is to add support to [Soul Fire'd](https://github.com/Crystal-Nest/soul-fire-d), but I also noticed and fixed a bug affecting both Hellfork and Soulfork.

First of all, I had to update the Gradle distribution version to 8.8 and Loom to 1.5-SNAPSHOT to build the project. For the same reason, I also had to remove some `.build()` calls from the loot table modify event.  
Secondly, I added Soul Fire'd v4.0.0 to the project as an optional dependency.  
Lastly, I noticed that entities killed by both Hellfork and Soulfork would drop raw food, so I fixed that. As I was doing this, I also added a new abstract class to reduce code duplication between the two tridents.

Fixes Impaled #44 and Soul Fire'd [#19](https://github.com/Crystal-Nest/soul-fire-d/issues/19).  
If compatibility for Soul Fire'd gets added, I will add Impaled to the [public list of mods](https://github.com/Crystal-Nest/soul-fire-d?tab=readme-ov-file#compatibilities) that support Soul Fire'd. Let me know if you don't want this.

If you have any question let me know!

List of changes:
- Project wide changes:
  * Updated `gradle-wrapper.properties` to go from Gradle `8.5` to `8.8`.
  * Updated `build.gradle` to upgrade Loom from `1.4-SNAPSHOT` to `1.5-SNAPSHOT`.
  * Updated `build.gradle` to add Crystal Nest Maven repo (Soul Fire'd is hosted there), Fuzs repo (FCAP, a required dependency for Soul Fire'd, is hosted there), and add Soul Fire'd `modImplementation`.
  * Updated `gradle.properties` to add `soul_fired_d_version`.
  * Updated `fabric.mod.json` to declare Soul Fire'd as an optional dependency.
  * Updated `ladysnake/impaled/common/Impaled.java` to fix compile errors.
  * Updated `ladysnake/impaled/common/init/ImpaledItems.java` to remove redundant calls to `.fireproof()` when instantiating Hellfork items.
- Soul Fire'd compatibility changes:
  * Added `ladysnake/impaled/compat/SoulFired.java` class to handle the optional dependency and compatibility.
  * Updated `ladysnake/impaled/common/item/HellforkItem.java` to use `SoulFired.java` class method if the item is a Soulfork one and Soul Fire'd is loaded at runtime.
  * Added `ladysnake/impaled/common/entity/FireTridentEntity.java` abstract class to greatly reduce code duplication between `SoulforkEntity` and `HellforkEntity`. Basically all the code has been moved there, and a new abstract method, `setTargetOnFireFor(LivingEntity, int)`, has been added to let each trident set targets on fire differently.
  * Implemented `setTargetOnFireFor` in `HellforkEntity` to simply call `target.setOnFireFor(seconds)`.
  * Implemented `setTargetOnFireFor` in `SoulforkEntity` to use `SoulFired` class if Soul Fire'd is loaded at runtime, otherwise do the same as `HellforkEntity`.
- Bug fix changes:
  * Added a new mixin method in `impaled.PlayerEntityMixin` to apply the "Vanilla workaround" of setting entities on fire before damaging them so that, if they happen to die in oneshot, their drops are cooked/smelted.
  * Added an override for `onEntityHit` in `FireTridentEntity` to apply the same workaround described in the previous point. After this, it still calls the super method.