### PR TITLE
fix: client crash when trying to send recalling packet after leaving server

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-	id 'fabric-loom' version "1.4-SNAPSHOT"
+	id 'fabric-loom' version "1.7-SNAPSHOT"
 	id 'io.github.ladysnake.chenille' version '0.11.3'
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.5-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.8-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/src/main/java/org/ladysnake/sincereloyalty/SincereLoyaltyClient.java
+++ b/src/main/java/org/ladysnake/sincereloyalty/SincereLoyaltyClient.java
@@ -65,10 +65,14 @@ public final class SincereLoyaltyClient implements ClientModInitializer {
 
     @Nullable
     private TridentRecaller.RecallStatus tickTridentRecalling(MinecraftClient mc) {
-        if (this.failedUseCountdown > 0) {
+        if (mc.player == null) {
+            this.failedUseCountdown = 0;
+            this.useTime = 0;
+            return null;
+        } else if (this.failedUseCountdown > 0) {
             PlayerEntity player = mc.player;
 
-            if (player != null && player.getMainHandStack().isEmpty()) {
+            if (player.getMainHandStack().isEmpty()) {
                 ++this.useTime;
 
                 if (this.useTime == RECALL_ANIMATION_START) {


### PR DESCRIPTION
fixes #62

If the player leaves the server while `SincereLoyalty.failedUseCountdown <= 0 && SincereLoyalty.useTime > 0`, then `tickTridentRecalling` on the next client tick will return a non-null `RecallStatus`, thus triggering a `impaled:recall_tridents` packet to be sent. But since the client is not connected to a server, upon trying to send this packet the client crashes.

This is fixed by checking in `tickTridentRecalling` whether the player is null - if it is, then `failedUseCountdown` and `useTime` are reset to 0 and null is returned.

Also two changes without which the mod did not compile for me:
- updated gradle wrapper to 8.8
- updated fabric-loom to 1.7-SNAPSHOT